### PR TITLE
CDBMeta: fix pagination warning for unordered list

### DIFF
--- a/cdbmeta/views.py
+++ b/cdbmeta/views.py
@@ -26,7 +26,7 @@ def cdbrecord(request, cdbrecord_id, fmt='html'):
 def cdb_search(request):
     cdbrecord_list = CDBRecord.objects.all()
     cdbrecord_filter = CDBRecordFilter(request.GET, queryset=cdbrecord_list)
-    filtered_qs = cdbrecord_filter.qs
+    filtered_qs = sorted(cdbrecord_filter.qs, key=lambda objects: objects.attribution.person.name)
 
     paginator = Paginator(filtered_qs, 10)
 


### PR DESCRIPTION
* Fixes UnorderedObjectListWarning: Pagination may yield inconsistent
  results with an unordered object_list.

Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>