### PR TITLE
Search template: remove domain name from URL

### DIFF
--- a/cdbmeta/templates/cdbmeta/search.html
+++ b/cdbmeta/templates/cdbmeta/search.html
@@ -102,7 +102,7 @@
         <a href="{% url 'cdbmeta:xml' cdbrecord.pk %}">xml</a> |
         <a href="{% url 'cdbmeta:txt' cdbrecord.pk %}">txt</a>
     </td>
-    <td><a href="https://cascadesdb.org/data/cdb/{{ cdbrecord.archive_name }}">{{ cdbrecord.qualified_id }}</a>{% if cdbrecord.archive_filesize %} ({{ cdbrecord.archive_filesize|filesizeformat }}){% endif %}</td>
+    <td><a href="/data/cdb/{{ cdbrecord.archive_name }}">{{ cdbrecord.qualified_id }}</a>{% if cdbrecord.archive_filesize %} ({{ cdbrecord.archive_filesize|filesizeformat }}){% endif %}</td>
 <td><a href="https://doi.org/{{ cdbrecord.attribution.publication_doi }}">link</a>{% if cdbrecord.attribution.source.bibtex %} | <a href="{% url 'refs:bibtex' cdbrecord.attribution.source.pk %}">bibtex</a>{% endif %}</td>
 </tr>
 {% endfor %}


### PR DESCRIPTION
* Removes the application domain name from the URL for the
  data files.

Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>