### PR TITLE
Templates: removal of hardcoded domain name

### DIFF
--- a/cdbmeta/templates/cdbmeta/doc.html
+++ b/cdbmeta/templates/cdbmeta/doc.html
@@ -9,9 +9,9 @@
 <p>Metadata for the CascadesDB database is provided in an XML format, which may be readily transformed into plain text or HTML by means of XSLT: links to all three formats are provided in the search results.</p>
 
 <ul>
-<li><a href="https://cascadesdb.org/static/xsd/cdbml-1.0.xsd">The CDBML XML Schema</a></li>
-<li><a href="https://cascadesdb.org/static/xsl/cdbml2html.xsl">CDBML to HTML XSL Stylesheet</a></li>
-<li><a href="https://cascadesdb.org/static/xsl/cdbml2txt.xsl">CDBML to plain text XSL Stylesheet</a></li>
+<li><a href="/static/xsd/cdbml-1.0.xsd">The CDBML XML Schema</a></li>
+<li><a href="/static/xsl/cdbml2html.xsl">CDBML to HTML XSL Stylesheet</a></li>
+<li><a href="/static/xsl/cdbml2txt.xsl">CDBML to plain text XSL Stylesheet</a></li>
 </ul>
 
 <p>A CDBML document consists of one or more <code>cdbrecord</code> elements inside a <code>cdbml</code> root element. Each <code>cdbrecord</code> represents the metadata for a set of collisional cascade simulations. Generally, a set of such simulations will differ only in the original PKA recoil direction, the other parameters (material, energy, temperature, etc.) given explicitly by the metadata.</p>


### PR DESCRIPTION
* Removes hardcoded domain name from documentation template.

Signed-off-by: Ludmila Marian <ludmila.marian@gmail.com>